### PR TITLE
Fixed logged in detection (OC 6.0.1)

### DIFF
--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -11,18 +11,15 @@ Given /^I am logged in$/ do
   fill_in 'password', with: "admin"
   click_button 'submit'
   #save_page
-  find('#settings').click
-  page.should have_selector('a#logout')
+  page.should have_selector('#header #settings')
 end
 
 When /^I am in the "([^"]*)" app$/ do |app|
   visit "/index.php?app=#{app}"
-  find('#settings').click
-  page.should have_selector('a#logout')
+  page.should have_selector('#header #settings')
 end
 
 When /^I go to "([^"]*)"$/ do |path|
   visit "#{path}"
-  find('#settings').click
-  page.should have_selector('a#logout')
+  page.should have_selector('#header #settings')
 end

--- a/features/step_definitions/my_steps.rb
+++ b/features/step_definitions/my_steps.rb
@@ -12,6 +12,5 @@ end
 
 Then /^I should be able to access my cloud$/ do
   visit '/'
-  find('#settings').click
-  page.should have_selector('a#logout')
+  page.should have_selector('#header #settings')
 end


### PR DESCRIPTION
Fixed logged in detection which seems to not work in OC 6.0.1.

Now instead of trying to click on the settings (which doesn't work when clicking directly on the ul), the selector only tried to detect whether there is a settings menu in the header which should be enough for now.

Please review @Gomez 
