### PR TITLE
Improved test script

### DIFF
--- a/test-stable.sh
+++ b/test-stable.sh
@@ -30,6 +30,17 @@ rvm use ruby-1.9.3-p194@oc_acceptance --create
 # let's assume bundler is installed
 bundle install
 
+# setup Vagrant plugins
+VAGRANT_PLUGINS="omnibus berkshelf"
+
+for PLUGIN in $VAGRANT_PLUGINS
+do
+	echo Checking for Vagrant plugin $PLUGIN
+	if ! vagrant plugin list | grep "$PLUGIN" > /dev/null 2>&1; then
+		vagrant plugin install "$PLUGIN"
+	fi
+done
+
 #
 # We need xvfb and virtual box. Check if these executables are in $PATH
 #
@@ -37,7 +48,7 @@ if [ ! `which xvfb-run` ]; then
   echo "You have to install xvfb in order to run the test suite"
   exit 1
 fi
-if [ ! `which vboxmanage` ]; then
+if [ ! `which vboxmanage || which VBoxManage` ]; then
   echo "You have to install virtualbox in order to run the test suite"
   exit 1
 fi
@@ -50,7 +61,7 @@ function run_tests {
 	#
 	# first start the vm(s)
 	#
-	vagrant up $VM_NAME
+	vagrant up $VM_NAME || echo "Failed to start VM" && exit 2
 
 	#
 	# Running the bdd test suite

--- a/test-stable.sh
+++ b/test-stable.sh
@@ -31,7 +31,7 @@ rvm use ruby-1.9.3-p194@oc_acceptance --create
 bundle install
 
 # setup Vagrant plugins
-VAGRANT_PLUGINS="omnibus berkshelf"
+VAGRANT_PLUGINS="vagrant-omnibus vagrant-berkshelf"
 
 for PLUGIN in $VAGRANT_PLUGINS
 do


### PR DESCRIPTION
- Added Vagrant plugin auto-install
- Fixed "VBoxManage" detection
- Stop the tests if vagrant didn't start

Note: these changes were mostly because I'm trying to run the tests on openSUSE 13.1 x84_64 and some things didn't match.

I'm still having trouble with Vagrant 1.4.3, I get this with the updated script from this PR:

```
IP for stable_on_apache_with_mysql: 192.168.10.10
Bringing machine 'stable_on_apache_with_mysql' up with 'virtualbox' provider...
There are errors in the configuration of this machine. Please fix
the following errors and try again:                                                                                                                                         

Vagrant:                                                                                                                                                                    
* Unknown configuration section 'berkshelf'.                                                                                                                                
* Unknown configuration section 'omnibus'. 
```

@Gomez any idea ? A quick Google didn't help.
Also: I'm very new to Vagrant...
